### PR TITLE
Add redirection argument to get-pure-port

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -49,7 +49,7 @@
 ; String -> String
 (define (get-url str)
   (string-trim (bytes->string/utf-8
-    (port->bytes (get-pure-port (string->url str))))))
+    (port->bytes (get-pure-port (string->url str) #:redirections 5)))))
 
 ; ----- Provides -----
 


### PR DESCRIPTION
The URLs used in the lab are now redirecting elsewhere. This makes `get-url` follow those redirects as one would expect.
