### PR TITLE
Add Makefile to build a .plt file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+COLLECT=cs2500f16-jsonlab
+TARGET=$(COLLECT).plt
+
+$TARGET:
+	mkdir $(COLLECT)
+	cp -r info.rkt main.rkt scribblings $(COLLECT)
+	raco link $(COLLECT)
+	raco pack --replace --collect $(TARGET) $(COLLECT)
+	raco link -r $(COLLECT)
+	rm -rf $(COLLECT)


### PR DESCRIPTION
The students aren't able to install packages on the lab computers, so I added a script to install this library as a Makefile instead (just run `make` at the command line while in this directory).
